### PR TITLE
feat: Add cross-platform setup and run scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,10 @@ This is an intelligent, interactive web application for planning your garden. It
 
 ## How to Run (Automated Setup)
 
-This project includes scripts to automate the setup and execution process, ensuring the application runs correctly every time.
+This project includes scripts to automate the setup and execution process for both Windows and Unix-like systems (Linux, macOS, WSL).
 
 ### 1. Prerequisites
 
-- Unix-like operating system (Linux, macOS, or WSL on Windows)
 - Python 3.7+
 - `git`
 
@@ -21,8 +20,14 @@ This project includes scripts to automate the setup and execution process, ensur
     ```
     *(Replace `<repository_url>` with the actual URL of the repository)*
 
-2.  **Run the setup script:**
-    This will create a virtual environment, install dependencies, and prepare the application.
+2.  **Run the appropriate setup script for your system:**
+
+    **For Windows:**
+    ```batch
+    setup.bat
+    ```
+
+    **For Linux/macOS/WSL:**
     ```bash
     chmod +x setup.sh
     ./setup.sh
@@ -30,40 +35,49 @@ This project includes scripts to automate the setup and execution process, ensur
 
 ### 3. Running the Application
 
-1.  **Run the application script:**
-    This will start the backend server on `http://localhost:8001`.
+1.  **Run the appropriate application script for your system:**
+
+    **For Windows:**
+    ```batch
+    run.bat
+    ```
+
+    **For Linux/macOS/WSL:**
     ```bash
     chmod +x run.sh
     ./run.sh
     ```
+
 2.  **Open your web browser** and navigate to `http://localhost:8001`. You should see the Garden Planner application.
 
 ---
 
 ## Why Use a Virtual Environment?
 
-The `setup.sh` script automatically creates a Python virtual environment (`venv`). This is a best practice for Python development for several reasons:
+The setup scripts automatically create a Python virtual environment (`venv`). This is a best practice for Python development for several reasons:
 
 - **Dependency Isolation:** It keeps the dependencies for this project separate from other projects on your system, preventing version conflicts.
 - **Reproducibility:** It ensures that the application is always run with the exact versions of the libraries it was tested with.
 - **Cleaner System:** It avoids cluttering your global Python installation with project-specific packages.
 
-You don't need to manually activate the virtual environment; the `run.sh` script handles it for you.
+You don't need to manually activate the virtual environment; the `run` scripts handle it for you.
 
 ## Manual Setup (Alternative)
 
 If you prefer to set up the project manually, you can follow these steps:
 
-1.  **Create and activate a virtual environment:**
+1.  **Create a virtual environment:**
     ```bash
-    python3 -m venv venv
-    source venv/bin/activate
+    python -m venv venv
     ```
-2.  **Install dependencies:**
+2.  **Activate it:**
+    - **Windows:** `venv\Scripts\activate`
+    - **Linux/macOS:** `source venv/bin/activate`
+3.  **Install dependencies:**
     ```bash
     pip install -r requirements.txt
     ```
-3.  **Run the server (from the project root):**
+4.  **Run the server (from the project root):**
     ```bash
     uvicorn backend.main:app --host 0.0.0.0 --port 8001
     ```

--- a/run.bat
+++ b/run.bat
@@ -1,0 +1,9 @@
+@echo off
+echo INFO: Activating virtual environment...
+call venv\Scripts\activate
+
+echo INFO: Starting Uvicorn server on port 8001...
+echo INFO: Access the application at http://localhost:8001
+echo INFO: Press Ctrl+C to stop the server.
+
+uvicorn backend.main:app --host 0.0.0.0 --port 8001

--- a/setup.bat
+++ b/setup.bat
@@ -1,0 +1,23 @@
+@echo off
+echo INFO: Checking for Python...
+python --version >nul 2>&1
+if %errorlevel% neq 0 (
+    echo ERROR: Python is not installed or not in PATH. Please install Python and try again.
+    exit /b 1
+)
+
+echo INFO: Creating virtual environment...
+if not exist venv (
+    python -m venv venv
+) else (
+    echo INFO: Virtual environment already exists.
+)
+
+echo INFO: Activating virtual environment...
+call venv\Scripts\activate
+
+echo INFO: Installing dependencies...
+pip install -r requirements.txt
+
+echo SUCCESS: Setup complete.
+echo INFO: You can now run the application using the run.bat script.


### PR DESCRIPTION
This commit introduces setup and run scripts for both Windows (`.bat`) and Unix-like (`.sh`) systems to automate the application startup process.

- `setup.bat` / `setup.sh`: Create a virtual environment and install dependencies.
- `run.bat` / `run.sh`: Activate the virtual environment and start the Uvicorn server on port 8001.

The `README.md` has been updated with clear instructions for both platforms, ensuring a smooth setup process for all users.

This resolves the issue of the garden planning interface not appearing due to incorrect server startup and improves the overall developer experience.