### PR TITLE
fix(frontend): Resolve JavaScript errors on page load

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -60,7 +60,7 @@
     <script src="https://cdn.socket.io/4.7.5/socket.io.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/controls/OrbitControls.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/zustand/dist/vanilla.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/zustand@4.5.7/umd/vanilla.production.js"></script>
     <script src="store.js"></script>
     <script src="script.js"></script>
 </body>

--- a/frontend/script.js
+++ b/frontend/script.js
@@ -12,6 +12,11 @@ document.addEventListener('DOMContentLoaded', () => {
     const raycaster = new THREE.Raycaster();
     // ... (other interaction variables)
 
+    // --- Event Handler for Mouse Down ---
+    function onMouseDown(event) {
+        // Placeholder for future implementation
+    }
+
     // --- RENDER/UPDATE LOOP ---
     function animate() {
         // ...


### PR DESCRIPTION
This commit addresses two critical JavaScript errors that occurred when the page was loaded:

1.  A `TypeError` was thrown in `store.js` because `window.zustand` was undefined. The CDN link in `index.html` for Zustand was pointing to a version that does not provide a browser-ready UMD build. This has been fixed by updating the `<script>` tag to use a compatible older version (v4) of Zustand from the jsDelivr CDN.

2.  A `ReferenceError` occurred in `script.js` because the `onMouseDown` function was used as an event listener without being defined. A placeholder for the `onMouseDown` function has been added to `script.js` to resolve this error.